### PR TITLE
Incorrectly scrolling to index on view appearance

### DIFF
--- a/Sources/Pageboy/Extensions/PageboyViewController+ScrollDetection.swift
+++ b/Sources/Pageboy/Extensions/PageboyViewController+ScrollDetection.swift
@@ -177,6 +177,7 @@ extension PageboyViewController: UIScrollViewDelegate {
             if self.autoScroller.restartsOnScrollEnd {
                 self.autoScroller.restart()
             }
+            self.expectedTransitionIndex = nil
         })
     }
     

--- a/Sources/Pageboy/PageboyViewController.swift
+++ b/Sources/Pageboy/PageboyViewController.swift
@@ -301,6 +301,7 @@ public extension PageboyViewController {
                                                                  didScrollTo: currentPosition,
                                                                  direction: direction,
                                                                  animated: animated)
+                            self.expectedTransitionIndex = nil
                         }
                     }
                     


### PR DESCRIPTION
In the case that a starts to page to a new index, but doesn't complete the process, the next index is cached but never cleared.  The next time the view appears, a scroll to is triggered using the cached next index.  This PR addresses this issue by clearing the cached next index once the paging is complete.